### PR TITLE
Document apt-get workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ issuing the following:
 
 ```shell
 umask 022
-sudo env -i ./vmdb2/vmdb2 --output raspi3.img raspi3.yaml --log raspi3.log
+sudo env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" PATH="$PATH" USER="$USER" \
+    ./vmdb2/vmdb2 --output raspi3.img raspi3.yaml --log raspi3.log
 ```
 
 ## Installing the image onto the Raspberry Pi 3

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ want to use:
     `apt-get` invocations with `apt-get -o Acquire::Check-Valid-Until=false`
 - If you want to use the latest versions of each software, you can replace
     `http://snapshot.debian.org/archive/debian/20171007T213914Z/` in raspi3.yaml
-    with the URL of your favorite Debian mirror. Of course, this means that the
+    with `http://deb.debian.org/debian`. Of course, this means that the
     build may break if there are regressions in the latest versions.
 
 Once you have edited raspi3.yaml, you can generate the image by

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ want to use:
     is pre-configured in raspi3.yaml. However, due to a [missing
     feature](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=763419) on
     snapshots, to make the build work, you have to disable an expiration check
-    by APT. To do so, edit [raspi3.yaml](raspi3.yaml) to replace all
+    by APT. To do so, edit raspi3.yaml to replace all
     `apt-get` invocations with `apt-get -o Acquire::Check-Valid-Until=false`
 - If you want to use the latest versions of each software, you can replace
     `http://snapshot.debian.org/archive/debian/20171007T213914Z/` in raspi3.yaml
     with the URL of your favorite Debian mirror. Of course, this means that the
     build may break if there are regressions in the latest versions.
 
-Once you have edited [raspi3.yaml](raspi3.yaml), you can generate the image by
+Once you have edited raspi3.yaml, you can generate the image by
 issuing:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ want to use:
     build may break if there are regressions in the latest versions.
 
 Once you have edited raspi3.yaml, you can generate the image by
-issuing:
+issuing the following:
 
 ```shell
-sudo ./vmdb2/vmdb2 --output raspi3.img raspi3.yaml --log raspi3.log
+umask 022
+sudo env -i ./vmdb2/vmdb2 --output raspi3.img raspi3.yaml --log raspi3.log
 ```
 
 ## Installing the image onto the Raspberry Pi 3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ See https://wiki.debian.org/RaspberryPi3#Preview_image for where to obtain the l
 ## Option 2: Building your own image
 
 If you prefer, you can build a Debian buster Raspberry Pi 3 image yourself. For
-this, first run the following:
+this, first install the
+[requirements](https://github.com/larswirzenius/vmdb2/blob/master/README#getting-vmdb2)
+of vmdb2. Then run the following:
 
 ```shell
 git clone --recursive https://github.com/Debian/raspi3-image-spec

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ issuing the following:
 
 ```shell
 umask 022
-sudo env -i HOME="$HOME" LC_CTYPE="${LC_ALL:-${LC_CTYPE:-$LANG}}" PATH="$PATH" USER="$USER" \
+sudo env -i LC_CTYPE=C.UTF-8 PATH="$PATH" \
     ./vmdb2/vmdb2 --output raspi3.img raspi3.yaml --log raspi3.log
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ want to use:
 - If you want to use the latest versions of each software, you can replace
     `http://snapshot.debian.org/archive/debian/20171007T213914Z/` in raspi3.yaml
     with `http://deb.debian.org/debian`. Of course, this means that the
-    build may break if there are regressions in the latest versions.
+    build may break or fail to boot if there are regressions in the latest
+    versions.
 
 Once you have edited raspi3.yaml, you can generate the image by
 issuing the following:

--- a/README.md
+++ b/README.md
@@ -9,11 +9,33 @@ See https://wiki.debian.org/RaspberryPi3#Preview_image for where to obtain the l
 
 ## Option 2: Building your own image
 
-If you prefer, you can build a Debian buster Raspberry Pi 3 image using:
+If you prefer, you can build a Debian buster Raspberry Pi 3 image yourself. For
+this, first run the following:
 
 ```shell
 git clone --recursive https://github.com/Debian/raspi3-image-spec
 cd raspi3-image-spec
+```
+
+Then edit [raspi3.yaml](raspi3.yaml) to select the Debian repository that you
+want to use:
+
+- If you want to use the snapshot with which the build was tested, use
+    `http://snapshot.debian.org/archive/debian/20171007T213914Z/`. This is what
+    is pre-configured in raspi3.yaml. However, due to a [missing
+    feature](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=763419) on
+    snapshots, to make the build work, you have to disable an expiration check
+    by APT. To do so, edit [raspi3.yaml](raspi3.yaml) to replace all
+    `apt-get` invocations with `apt-get -o Acquire::Check-Valid-Until=false`
+- If you want to use the latest versions of each software, you can replace
+    `http://snapshot.debian.org/archive/debian/20171007T213914Z/` in raspi3.yaml
+    with the URL of your favorite Debian mirror. Of course, this means that the
+    build may break if there are regressions in the latest versions.
+
+Once you have edited [raspi3.yaml](raspi3.yaml), you can generate the image by
+issuing:
+
+```shell
 sudo ./vmdb2/vmdb2 --output raspi3.img raspi3.yaml --log raspi3.log
 ```
 
@@ -36,6 +58,3 @@ ssh root@rpi3
 # Enter password “raspberry”
 ```
 
-## Reproducibility
-
-The image currently uses http://snapshot.debian.org/archive/debian/20171007T213914Z/ for ensuring a reproducible build.


### PR DESCRIPTION
Hi, this is as discussed in issue #1. I also documented the need to install the dependencies of vmdb2, if that's OK.

By the way, one other thing that could maybe be documented is the fact that building the image fails mysteriously ("cannot run apt-key") if the user running the build has another umask that 022 (see [here](https://github.com/larswirzenius/vmdb2/issues/26#issuecomment-339157527)). I don't know whether you think it's a relevant point to document, but it's the main problem I had to debug when building the image. What do you think?