### PR TITLE
Add filesystem labels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vmdb2"]
 	path = vmdb2
-	url = https://github.com/chschlue/vmdb2.git
-	branch = fs-labels
+	url = git://git.liw.fi/vmdb2.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vmdb2"]
 	path = vmdb2
-	url = https://github.com/larswirzenius/vmdb2.git
+	url = https://github.com/chschlue/vmdb2.git
+	branch = fs-labels

--- a/fstab
+++ b/fstab
@@ -1,5 +1,5 @@
 # The root file system has fs_passno=1 as per fstab(5) for automatic fsck.
-/dev/mmcblk0p2 / ext4 rw 0 1
+LABEL=root / ext4 rw 0 1
 # All other file systems have fs_passno=2 as per fstab(5) for automatic fsck.
-/dev/mmcblk0p1 /boot/firmware vfat rw 0 2
+LABEL=boot /boot/firmware vfat rw 0 2
 proc /proc proc defaults 0 0

--- a/raspi3.yaml
+++ b/raspi3.yaml
@@ -22,9 +22,11 @@ steps:
 
   - mkfs: vfat
     partition: boot-part
+    label: boot
 
   - mkfs: ext4
     partition: root-part
+    label: root
 
   - mount: root-part
     fs-tag: root-fs


### PR DESCRIPTION
Update vmdb2 submodule to current version.
Add fs labels to raspi3.yaml.
Mount /root and /boot by label.

Squashes bug #17 