### PR TITLE
Revert "Fix the cmdline.txt options to boot by label, not by partition"

### DIFF
--- a/raspi3.yaml
+++ b/raspi3.yaml
@@ -124,12 +124,6 @@ steps:
       apt-get clean
       rm -rf /var/lib/apt/lists
 
-  # Modify the kernel commandline we take from the firmware to boot from
-  # the partition labeled raspiroot instead of forcing it to mmcblk0p2
-  - chroot: root-fs
-    shell: |
-      sed -i 's/.dev.mmcblk0p2/LABEL=raspiroot/' ${ROOT?}/boot/firmware/cmdline.txt
-
   # TODO(https://github.com/larswirzenius/vmdb2/issues/24): remove once vmdb
   # clears /etc/resolv.conf on its own.
   - shell: |


### PR DESCRIPTION
This reverts commit 554020cc949be4803e83bd4bd9f1f76c2ad73d10.

This change wasn't functional, ${ROOT?} does not make sense in a chroot.

Also, I suggest fixing this in raspi3-firmware, cmdline.txt would get overwritten anyway on every kernel update.