### PR TITLE
Install kernel and firmware from Buster

### DIFF
--- a/raspi3.yaml
+++ b/raspi3.yaml
@@ -74,18 +74,9 @@ steps:
     - firmware-brcm80211
     - wireless-tools
     - wpasupplicant
+    - raspi3-firmware
+    - linux-image-arm64
     fs-tag: root-fs
-
-  # TODO: install raspi3-firmware and linux-image-arm64 from buster once they
-  # migrated in sufficiently recent versions.
-  - chroot: root-fs
-    shell: |
-      echo 'deb http://deb.debian.org/debian unstable main contrib non-free' >> /etc/apt/sources.list
-      echo 'deb http://deb.debian.org/debian experimental main contrib non-free' >> /etc/apt/sources.list
-      echo 'APT::Default-Release "buster";' > /etc/apt/apt.conf.d/08default-release
-      apt-get update
-      apt-get -y --no-show-progress -t unstable install raspi3-firmware
-      apt-get -y --no-show-progress -t experimental install linux-image-4.18.0-rc5-arm64-unsigned
 
   - shell: |
       echo "rpi3" > "${ROOT?}/etc/hostname"


### PR DESCRIPTION
Kernel 4.18 and raspi3-firmware 1.20180619-1 are now included in Buster,
so we no longer need to install those from unstable or experimental.