### PR TITLE
Raspi Zero W Support

### DIFF
--- a/raspi0w.yaml
+++ b/raspi0w.yaml
@@ -132,10 +132,14 @@ steps:
 
   # Modify the kernel commandline we take from the firmware to boot from
   # the partition labeled raspiroot instead of forcing it to mmcblk0p2
+  #
+  # Enable UART in the boot loader to debug
+  #
   - chroot: /
     shell: |
       ls -aR /boot
       sed -i 's/.dev.mmcblk0p2/LABEL=RASPIROOT/' /boot/firmware/cmdline.txt
+      sed -i 's/BOOT_UART=0/BOOT_UART=1/' /boot/firmware/bootcode.bin
 
   # TODO(https://github.com/larswirzenius/vmdb2/issues/24): remove once vmdb
   # clears /etc/resolv.conf on its own.

--- a/raspi0w.yaml
+++ b/raspi0w.yaml
@@ -1,0 +1,144 @@
+# See https://wiki.debian.org/RaspberryPi3 for known issues and more details.
+
+steps:
+  - mkimg: "{{ output }}"
+    size: 1500M
+
+  - mklabel: msdos
+    device: "{{ output }}"
+
+  - mkpart: primary
+    fs-type: 'fat32'
+    device: "{{ output }}"
+    start: 0%
+    end: 20%
+    tag: /boot
+
+  - mkpart: primary
+    device: "{{ output }}"
+    start: 20%
+    end: 100%
+    tag: /
+
+  - kpartx: "{{ output }}"
+
+  - mkfs: vfat
+    partition: /boot
+    label: RASPIFIRM
+
+  - mkfs: ext4
+    partition: /
+    label: RASPIROOT
+
+  - mount: /
+
+  - mount: /boot
+    mount-on: /
+    dirname: '/boot/firmware'
+
+  - unpack-rootfs: /
+
+  # We need to use Debian buster (currently testing) instead of Debian stretch
+  # (currently stable) for:
+  #
+  # linux ≥ 4.14
+  #   Which includes the sdhost driver for faster SD card access and making the
+  #   WiFi chip available, and has the WiFi driver enabled.
+  #
+  # raspi3-firmware ≥ 1.20171201-1
+  #   Which includes a recent enough firmware version to correctly pass the MAC
+  #   address to the kernel. This is a regression with Linux ≥ 4.12, see
+  #   https://github.com/raspberrypi/firmware/issues/846
+  #   Also, this package contains a Raspberry Pi 3-specific firmware file
+  #   required by the WiFi driver.
+  - qemu-debootstrap: buster
+    mirror: http://deb.debian.org/debian
+    target: /
+    arch: armel
+    components:
+    - main
+    - contrib
+    - non-free
+    unless: rootfs_unpacked
+
+  # TODO(https://bugs.debian.org/877855): remove this workaround once
+  # debootstrap is fixed
+  - chroot: /
+    shell: |
+      echo 'deb http://deb.debian.org/debian buster main contrib non-free' > /etc/apt/sources.list
+      apt-get update
+    unless: rootfs_unpacked
+
+  - apt: install
+    packages:
+    - ssh
+    - parted
+    - dosfstools
+    # Contains /lib/firmware/brcm/brcmfmac43430-sdio.bin (required for WiFi).
+    - firmware-brcm80211
+    - wireless-tools
+    - wpasupplicant
+    - raspi3-firmware
+    - linux-image-marvell
+    tag: /
+    unless: rootfs_unpacked
+
+  - cache-rootfs: /
+    unless: rootfs_unpacked
+
+  - shell: |
+      echo "rpi-z" > "${ROOT?}/etc/hostname"
+
+      # '..VyaTFxP8kT6' is crypt.crypt('raspberry', '..')
+      sed -i 's,root:[^:]*,root:..VyaTFxP8kT6,' "${ROOT?}/etc/shadow"
+
+      sed -i 's,#PermitRootLogin prohibit-password,PermitRootLogin yes,g' "${ROOT?}/etc/ssh/sshd_config"
+
+      install -m 644 -o root -g root fstab "${ROOT?}/etc/fstab"
+
+      install -m 644 -o root -g root eth0 "${ROOT?}/etc/network/interfaces.d/eth0"
+
+      mkdir -p "${ROOT?}/etc/iptables"
+      install -m 644 -o root -g root rules.v4 "${ROOT?}/etc/iptables/rules.v4"
+      install -m 644 -o root -g root rules.v6 "${ROOT?}/etc/iptables/rules.v6"
+
+      install -m 755 -o root -g root rpi3-resizerootfs "${ROOT?}/usr/sbin/rpi3-resizerootfs"
+      install -m 644 -o root -g root rpi3-resizerootfs.service "${ROOT?}/etc/systemd/system"
+      mkdir -p "${ROOT?}/etc/systemd/system/systemd-remount-fs.service.requires/"
+      ln -s /etc/systemd/system/rpi3-resizerootfs.service "${ROOT?}/etc/systemd/system/systemd-remount-fs.service.requires/rpi3-resizerootfs.service"
+
+      install -m 644 -o root -g root rpi3-generate-ssh-host-keys.service "${ROOT?}/etc/systemd/system"
+      mkdir -p "${ROOT?}/etc/systemd/system/multi-user.target.requires/"
+      ln -s /etc/systemd/system/rpi3-generate-ssh-host-keys.service "${ROOT?}/etc/systemd/system/multi-user.target.requires/rpi3-generate-ssh-host-keys.service"
+      rm -f ${ROOT?}/etc/ssh/ssh_host_*_key*
+
+      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-b.dtb      -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
+      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-b-plus.dtb -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
+      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-0-w.dtb    -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
+      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-cm.dtb    -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
+
+      cat >> "${ROOT?}/etc/motd" <<'EOT'
+
+      Please change the root password by running passwd
+      EOT
+    root-fs: /
+
+  # Clean up archive cache (likely not useful) and lists (likely outdated) to
+  # reduce image size by several hundred megabytes.
+  - chroot: /
+    shell: |
+      apt-get clean
+      rm -rf /var/lib/apt/lists
+
+  # Modify the kernel commandline we take from the firmware to boot from
+  # the partition labeled raspiroot instead of forcing it to mmcblk0p2
+  - chroot: /
+    shell: |
+      ls -aR /boot
+      sed -i 's/.dev.mmcblk0p2/LABEL=RASPIROOT/' /boot/firmware/cmdline.txt
+
+  # TODO(https://github.com/larswirzenius/vmdb2/issues/24): remove once vmdb
+  # clears /etc/resolv.conf on its own.
+  - shell: |
+      rm "${ROOT?}/etc/resolv.conf"
+    root-fs: /

--- a/raspi0w.yaml
+++ b/raspi0w.yaml
@@ -51,7 +51,7 @@ steps:
   #   https://github.com/raspberrypi/firmware/issues/846
   #   Also, this package contains a Raspberry Pi 3-specific firmware file
   #   required by the WiFi driver.
-  - qemu-debootstrap: buster
+  - qemu-debootstrap: sid
     mirror: http://deb.debian.org/debian
     target: /
     arch: armel
@@ -65,7 +65,7 @@ steps:
   # debootstrap is fixed
   - chroot: /
     shell: |
-      echo 'deb http://deb.debian.org/debian buster main contrib non-free' > /etc/apt/sources.list
+      echo 'deb http://deb.debian.org/debian sid main contrib non-free' > /etc/apt/sources.list
       apt-get update
     unless: rootfs_unpacked
 

--- a/raspi0w.yaml
+++ b/raspi0w.yaml
@@ -112,10 +112,7 @@ steps:
       ln -s /etc/systemd/system/rpi3-generate-ssh-host-keys.service "${ROOT?}/etc/systemd/system/multi-user.target.requires/rpi3-generate-ssh-host-keys.service"
       rm -f ${ROOT?}/etc/ssh/ssh_host_*_key*
 
-      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-b.dtb      -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
-      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-b-plus.dtb -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
-      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-0-w.dtb    -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
-      wget https://github.com/raspberrypi/firmware/blob/master/boot/bcm2708-rpi-cm.dtb    -O "${ROOT?}/boot/bcm2708-rpi-0-w.dtb"
+      cp "${ROOT?}/usr/lib/linux-image-4.19.0.5-rpi/bcm2835-rpi-zero-w.dtb" "${ROOT?}/boot/"
 
       cat >> "${ROOT?}/etc/motd" <<'EOT'
 
@@ -134,12 +131,17 @@ steps:
   # the partition labeled raspiroot instead of forcing it to mmcblk0p2
   #
   # Enable UART in the boot loader to debug
+  # 
+  # Tell start.elf that the kernel is upstream, so the BCM2835 dtb gets loaded
+  # From:
+  # https://www.raspberrypi.org/forums/viewtopic.php?p=1456353&sid=4fb9bf969c9ef5594f38e028b36e39c6#p1456353
   #
   - chroot: /
     shell: |
       ls -aR /boot
       sed -i 's/.dev.mmcblk0p2/LABEL=RASPIROOT/' /boot/firmware/cmdline.txt
       sed -i 's/BOOT_UART=0/BOOT_UART=1/' /boot/firmware/bootcode.bin
+      sed -i '/enable_uart=1/a upstream_kernel=1' /boot/firmware/config.txt
 
   # TODO(https://github.com/larswirzenius/vmdb2/issues/24): remove once vmdb
   # clears /etc/resolv.conf on its own.

--- a/raspi0w.yaml
+++ b/raspi0w.yaml
@@ -79,7 +79,7 @@ steps:
     - wireless-tools
     - wpasupplicant
     - raspi3-firmware
-    - linux-image-marvell
+    - linux-image-rpi
     tag: /
     unless: rootfs_unpacked
 


### PR DESCRIPTION
After a few false starts, I managed to get a Debian image to boot on a Raspi Zero W.

This is only a minimal configuration to get the Pi to boot. Testing of the peripherals hasn't been performed, so may need more work.

One issue I did run into was a corrupt initrd. A rebuild seemed to fix it. The bootloader will spit out a "uncompression failed" message if this is the case.

There are a few changes compared to the Raspi 1 specs:

1. Using Sid rather than Buster, for no reason other than being on Sid.
2. Using the "rpi" kernel instead of the "marvell" kernel.
3. Use the upstream Device Tree, so we don't need to "wget" from the Raspbian kernel repo.
